### PR TITLE
Update: add close button on sidebar

### DIFF
--- a/frontend/src/components/PluginGeneratorPage.css
+++ b/frontend/src/components/PluginGeneratorPage.css
@@ -53,6 +53,16 @@
   text-align: center;
 } */
 
+.close-sidebar {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: silver;
+    cursor: pointer;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+}
 
 .input-wrapper {
   bottom: 0;
@@ -119,11 +129,12 @@
   font-size: 1rem;
   color: #666;
   margin-bottom: 0.5rem;
+  margin-left: 3%;
 }
 
 .recent-chats ul {
   list-style: none;
-  padding: 0;
+  padding: 18px;
 }
 
 .recent-chats li {
@@ -336,6 +347,9 @@
 
 /* Responsive */
 @media (max-width: 768px) {
+  .recent-chats{
+    width: 100vh;
+  }
   .layout {
     flex-direction: column;
   }
@@ -366,7 +380,7 @@
     overflow-y: auto;
     background-color: var(--bg-color);
     z-index: var(--overlay-z);
-    padding: 1.5rem;
+    padding: 0rem;
     box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
   }
 

--- a/frontend/src/components/PluginGeneratorPage.jsx
+++ b/frontend/src/components/PluginGeneratorPage.jsx
@@ -150,6 +150,10 @@ const PluginGeneratorPage = () => {
             setIsSidebarOpen(false);
         }
     };
+    const handleCloseSidebar = () => {
+    setIsSidebarOpen(false);
+    };
+
 
     // Helper to render message content, especially for developer messages
     const renderMessageContent = (msg) => {
@@ -188,6 +192,7 @@ const PluginGeneratorPage = () => {
                     <div className="sidebar-top">
                         <hr></hr>
                         <h2 className="logo">MakePlugin</h2>
+                        <button className="close-sidebar" onClick={handleCloseSidebar}>×</button>
                         <hr></hr>
                         <button className="new-chat" onClick={handleResetChat}>Generate A New Plugin</button>
                     </div>


### PR DESCRIPTION
**feat: add close button to sidebar component**

Implemented a close (×) button in the sidebar UI to allow users to manually close the sidebar. Added `handleCloseSidebar` function to update the `isSidebarOpen` state to `false`. Improves user experience, especially on smaller screens and mobile devices.
